### PR TITLE
Adds screenshot capability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module path-variable.com/onvif
 
 go 1.17
 
-require github.com/use-go/onvif v0.0.1
+require (
+	github.com/use-go/onvif v0.0.1
+	gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc
+)
 
 require (
 	github.com/beevik/etree v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,11 @@ module path-variable.com/onvif
 go 1.17
 
 require github.com/use-go/onvif v0.0.1
+
+require (
+	github.com/beevik/etree v1.1.0 // indirect
+	github.com/elgs/gostrgen v0.0.0-20161222160715-9d61ae07eeae // indirect
+	github.com/gofrs/uuid v3.2.0+incompatible // indirect
+	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect
+	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,9 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc h1:LMEBgNcZUqXaP7evD1PZcL6EcDVa2QOFuI+cqM3+AJM=
+gopkg.in/xmlpath.v2 v2.0.0-20150820204837-860cbeca3ebc/go.mod h1:N8UOSI6/c2yOpa/XDz3KVUiegocTziPiqNkeNTMiG1k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/motion-poll.go
+++ b/motion-poll.go
@@ -28,7 +28,7 @@ import (
      7 - (optional) json message template for sprintf ex. ./motion-poll "${<file.json}"
 */
 
-const ssErrorTmplt = "Error while getting snapshot %s\n"
+const ssErrorTemplate = "Error while getting snapshot %s\n"
 
 const soap = `
 <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
@@ -124,20 +124,20 @@ func main() {
 func getSnapshot(url, path string) {
 	r, e := http.Get(url)
 	if e != nil {
-		fmt.Printf(ssErrorTmplt, e)
+		fmt.Printf(ssErrorTemplate, e)
 		return
 	}
 	defer r.Body.Close()
 
 	file, e := os.Create(fmt.Sprintf("%s/%s.jpeg", path, time.Now().Format("20060102150405")))
 	if e != nil {
-		fmt.Printf(ssErrorTmplt, e)
+		fmt.Printf(ssErrorTemplate, e)
 		return
 	}
 	defer file.Close()
 
 	_, e = io.Copy(file, r.Body)
 	if e != nil {
-		fmt.Printf(ssErrorTmplt, e)
+		fmt.Printf(ssErrorTemplate, e)
 	}
 }

--- a/motion-poll.go
+++ b/motion-poll.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -22,8 +23,9 @@ import (
      2 - password
      3 - camera name (or location)
      4 - slack hook url
-     5 - (optional) cooldown time after motion event detected
-     6 - (optional) json message template for sprintf ex. ./motion-poll "${<file.json}"
+	 5 - snapshot save path
+     6 - (optional) cooldown time after motion event detected
+     7 - (optional) json message template for sprintf ex. ./motion-poll "${<file.json}"
  */
 func main() {
 	// get and validate number of cli args
@@ -49,8 +51,8 @@ func main() {
 	// get slack message from template - use default if cli arg is not given
 	camName := args[3]
 	var msgT string
-	if len(args) > 6 {
-		msgT = args[6]
+	if len(args) > 7 {
+		msgT = args[7]
 	} else {
 		msgT = ` 
     	{
@@ -61,8 +63,8 @@ func main() {
 
 	//get cooldown time from args, default 10 seconds
 	cooldown := 10
-	if len(args) > 5 {
-		convInt, err := strconv.Atoi(args[5])
+	if len(args) > 6 {
+		convInt, err := strconv.Atoi(args[6])
 		if err == nil {
 			cooldown = convInt
 		} else {
@@ -77,15 +79,27 @@ func main() {
 		bodyBytes, _ := ioutil.ReadAll(r2.Body)
 		bodyS := string(bodyBytes)
 		if strings.Contains(bodyS, "<tt:SimpleItem Name=\"IsMotion\" Value=\"true\" />") {
-			fmt.Printf("%s", bodyS)
 			msg := fmt.Sprintf(msgT, camName)
 			_, err = http.Post(args[4], "aplication/json", bytes.NewReader([]byte(msg)))
 			if err != nil {
 				fmt.Printf("there was an error while posting the slack notification %s", err)
 			}
+			captureScreenshot(args[0], args[1], args[2], args[5])
 			time.Sleep(time.Duration(cooldown) * time.Second)
 		}
 		time.Sleep(1 * time.Second)
 	}
 
+}
+
+func captureScreenshot(url, user, pass, imgPath string) {
+	path := fmt.Sprintf("%s/%s.jpeg",imgPath, time.Now().Format("20060102150405"))
+	curl := strings.Split(url, ":")[0]
+	rurl := fmt.Sprintf("rtsp://%s/user=%s_password=%s_channel=1_stream=1.sdp", curl, user, pass)
+	fmt.Printf("taking screenshot %s\n", rurl)
+	cmd := exec.Command("ffmpeg", "-y", "-i", rurl, "-vframes","1", path)
+	err := cmd.Run()
+	if err != nil {
+		fmt.Printf("Screnshot error is %s", err)
+	}
 }


### PR DESCRIPTION
Changes:


- Uses ONVIF service to get the snapshot url from the camera. 
- Uses said url to take a snapshot from the camera once the motion poll brings back an event.
- If the url cannot be retrieved, no snapshot is taken but the script continues to operate as normal, 
posting notifications to the slack webhook.


The order of script argments has changed. 
Please look at the comment in `motion-poll.go` itself.
